### PR TITLE
remove some warnings

### DIFF
--- a/src/ofxMathSurface.cpp
+++ b/src/ofxMathSurface.cpp
@@ -105,7 +105,8 @@ void ofxMathSurface::drawNormals(float length) const{
     
     for(int i = 0; i < (int)frontFaceNormals.size(); i++) {
         vert = vertices[i];
-        normal = normals[i].normalized();
+        normal = normals[i];
+        normal.normalize();
         normalsMesh.setVertex( i*2, vert);
         normal *= length;
         normalsMesh.setVertex(i*2+1, normal+vert);
@@ -116,9 +117,10 @@ void ofxMathSurface::drawNormals(float length) const{
     
     normalsMesh.getVertices().resize( backFaceNormals.size() * 2);
     const vector<ofVec3f>& backNormals = backFaceNormals;
-    for(int i = 0; i < (int)backFaceNormals.size(); i++) {
+    for(int i = 0; i < (int)backNormals.size(); i++) {
         vert = vertices[i];
-        normal = backFaceNormals[i].normalized();
+        normal = backNormals[i];
+        normal.normalize();
         normalsMesh.setVertex( i*2, vert);
         normal *= length;
         normalsMesh.setVertex(i*2+1, normal+vert);
@@ -139,7 +141,6 @@ void ofxMathSurface::drawFaceNormals(float length) const {
     ofMesh nMesh;
     nMesh.setMode(OF_PRIMITIVE_LINES);
     const vector<ofVec3f> &verts = vertices;
-    int c = 0;
     for (int i = 0; i < verts.size(); i+=3) {
         ofVec3f v1 = verts[i];
         ofVec3f v2 = verts[i+1];

--- a/src/ofxParametricSurface.cpp
+++ b/src/ofxParametricSurface.cpp
@@ -134,7 +134,7 @@ ofVec3f ofxParametricSurface::normalForPoint(float u, float v,ofPoint value){
 //    
 //    ofVec3f dv = (dvRight + -dvLeft);
     
-    ofVec3f normal = duRight.crossed(dvRight).normalized();
+    ofVec3f normal = duRight.cross(dvRight).normalize();
     return -normal;
 }
 


### PR DESCRIPTION
In this PR:
- remove some deprecation warnings about `.crossed` and `.normalized`
- remove a warning about `backNormals` and `c` not being used 

Tested all the examples and they still work.
macOS sierra 10.12.3
OF 0.9.8

Thanks for such a great addon. 